### PR TITLE
Update Website URL Handling in macos_grok_overlay/app.py

### DIFF
--- a/macos_grok_overlay/app.py
+++ b/macos_grok_overlay/app.py
@@ -116,7 +116,8 @@ class AppDelegate(NSObject):
         content_view.addSubview_(self.webview)
         self.webview.setFrame_(NSMakeRect(0, 0, content_bounds.size.width, content_bounds.size.height - DRAG_AREA_HEIGHT))
         # Contat the target website.
-        url = NSURL.URLWithString_(WEBSITE)
+        website_url = os.environ.get("MY_WEBSITE", WEBSITE)
+        url = NSURL.URLWithString_(website_url)
         request = NSURLRequest.requestWithURL_(url)
         self.webview.loadRequest_(request)
         # Set up script message handler for background color changes
@@ -226,7 +227,8 @@ class AppDelegate(NSObject):
     
     # Go to the default landing website for the overlay (in case accidentally navigated away).
     def goToWebsite_(self, sender):
-        url = NSURL.URLWithString_(WEBSITE)
+        website_url = os.environ.get("MY_WEBSITE", WEBSITE)
+        url = NSURL.URLWithString_(website_url)
         request = NSURLRequest.requestWithURL_(url)
         self.webview.loadRequest_(request)
     


### PR DESCRIPTION
# Update Website URL Handling in macos_grok_overlay/app.py

## Description
Modified the `applicationDidFinishLaunching_` method to use an environment variable (`MY_WEBSITE`) for the website URL instead of a hardcoded `WEBSITE` value. This allows for more flexible configuration of the target website.

## Changes Made
- [x] Replaced `NSURL.URLWithString_(WEBSITE)` with dynamic `website_url` from `os.environ.get('MY_WEBSITE', WEBSITE)`

## Testing
- Tested locally by setting the `MY_WEBSITE` environment variable and verifying the webview loads the correct URL.
